### PR TITLE
fix: prop forwarding + input field handling

### DIFF
--- a/src/components/IconPicker/Input.tsx
+++ b/src/components/IconPicker/Input.tsx
@@ -44,12 +44,7 @@ export const IconPickerInput: React.FC<IconPickerInputProps> = (props) => {
   const { i18n, t } = useTranslation()
 
   const handleChange = (evt: ChangeEvent<HTMLInputElement>) => {
-    if (!evt.target.value.startsWith('#')) {
-      evt.target.value = `#${evt.target.value}`
-    }
-
-    evt.target.value = evt.target.value.replace(/[^a-f0-9#]/gi, '').slice(0, 7)
-
+    setSearch(evt.target.value)
     onChange?.(evt as any)
   }
 

--- a/src/components/IconPicker/index.tsx
+++ b/src/components/IconPicker/index.tsx
@@ -89,6 +89,7 @@ const IconPickerField: IconPickerFieldClientComponent = (props) => {
       style={styles}
       value={(value as string) || ''}
       icons={icons}
+      placeholder={placeholder}
     />
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export const iconPickerField = (
         Field: {
           clientProps: {
             icons: icons,
+            readOnly: rest?.admin?.readOnly,
           },
           path: '@innovixx/payload-icon-picker-field/components#IconPickerFieldComponent',
         },


### PR DESCRIPTION
Fixes placeholder pass forward.
Adds readOnly to client component props for proper application.
Modify input field's OnChange handler to no longer apply a hexcode restriction.
Additionally allow input field to act as a search

readOnly currently disables the main input field, but onClick -> menu functionality still works.
Possibly look into two different options:
- Current functionality of only partially readOnly
- Fully disable IconPicker field to be fully readOnly
