### PR TITLE
fix: use semver range for next peer dependency and bump version to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innovixx/payload-icon-picker-field",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage:": "https://innovixx.co.uk",
   "repository": "git@github.com:Innovixx-Development/payload-icon-picker-field.git",
   "description": "payload-icon-picker-field",
@@ -25,7 +25,7 @@
   "author": "support@innovixx.co.uk",
   "license": "MIT",
   "peerDependencies": {
-    "next": "15.1.9",
+    "next": ">=15.1.9",
     "payload": "^3.2.2",
     "react": "^19.0.0"
   },


### PR DESCRIPTION
Change next peer dependency from exact version pin (15.1.9) to
  minimum version (>=15.1.9) to allow compatibility with Next.js 16.x
  while maintaining the CVE-2025-66478 security requirement.

resolves https://github.com/innovixx/payload-icon-picker-field/issues/11